### PR TITLE
fix: windows path issue

### DIFF
--- a/wayback-machine-downloader/lib/asset-manager.js
+++ b/wayback-machine-downloader/lib/asset-manager.js
@@ -57,7 +57,7 @@ class AssetManager {
     if (fileId.length > 200) return null;
 
     const backup = this.backupPath;
-    const parts = fileId.split("/").filter(Boolean);
+    const parts = fileId.split("/").filter(Boolean).map((p) => this.windowsSanitize(p));
     let dirPath;
     let filePath;
 
@@ -74,9 +74,6 @@ class AssetManager {
         filePath = path.join(backup, ...parts);
       }
     }
-
-    dirPath = this.windowsSanitize(dirPath);
-    filePath = this.windowsSanitize(filePath);
 
     return { dirPath, filePath };
   }


### PR DESCRIPTION
On windows tool can't recreate proper path in FS, see https://github.com/birbwatcher/wayback-machine-downloader/issues/13
Tested on couple of captures.